### PR TITLE
Change cipher for secret storage

### DIFF
--- a/src/main/java/tiqr/org/secure/SecretCipher.java
+++ b/src/main/java/tiqr/org/secure/SecretCipher.java
@@ -23,14 +23,14 @@ public class SecretCipher {
 
     @SneakyThrows
     public String encrypt(String sharedSecret) {
-        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
         cipher.init(Cipher.ENCRYPT_MODE, secretKey);
         return Base64.getEncoder().encodeToString(cipher.doFinal(sharedSecret.getBytes(UTF_8)));
     }
 
     @SneakyThrows
     public String decrypt(String encodedEncryptedSecret) {
-        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5PADDING");
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
         cipher.init(Cipher.DECRYPT_MODE, secretKey);
         return new String(cipher.doFinal(Base64.getDecoder().decode(encodedEncryptedSecret)));
     }

--- a/src/test/java/tiqr/org/secure/SecretCipherTest.java
+++ b/src/test/java/tiqr/org/secure/SecretCipherTest.java
@@ -13,13 +13,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SecretCipherTest {
 
-    private final SecretCipher secretCipher = new SecretCipher("1");
+    private final SecretCipher secretCipher = new SecretCipher(UUID.randomUUID().toString());
 
     @Test
-    void encrypt() throws NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
+    void encrypt() {
         String sharedSecret = UUID.randomUUID().toString();
         String encrypted = secretCipher.encrypt(sharedSecret);
         String decrypted = secretCipher.decrypt(encrypted);
+        assertEquals(sharedSecret, decrypted);
+    }
+
+    @Test
+    void ensureThreadConsistency() {
+        String secret = UUID.randomUUID().toString();
+        SecretCipher firstSecretCipher = new SecretCipher(secret);
+        SecretCipher secondSecretCipher = new SecretCipher(secret);
+
+        String sharedSecret = UUID.randomUUID().toString();
+        String encrypted = firstSecretCipher.encrypt(sharedSecret);
+        String decrypted = secondSecretCipher.decrypt(encrypted);
         assertEquals(sharedSecret, decrypted);
     }
 


### PR DESCRIPTION
AES ECB with PKCS5 padding is a very insecure cipher. It allows for plaintext modifications and for attacks called padding oracle attacks.
@oharsta Will this break anything besides current registrations?